### PR TITLE
Fix Docker build by using Yarn 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM node:18-alpine AS builder
 WORKDIR /app
 
 COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
 
-RUN yarn install --frozen-lockfile
+RUN corepack enable \
+  && corepack prepare yarn@4.9.4 --activate \
+  && yarn install --immutable
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- copy the repository's .yarn directory into the Docker build context
- enable Corepack and activate Yarn 4 before installing dependencies, allowing the existing lockfile to be respected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de418773f0832a8cfd62a38a3627a7