### PR TITLE
Install build dependencies in Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 
+RUN apk add --no-cache python3 make g++
+
 COPY package.json yarn.lock .yarnrc.yml ./
 # COPY .yarn .yarn
 


### PR DESCRIPTION
## Summary
- install python, make, and g++ in the Docker build stage so native modules can compile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de45646f90832ab4a717f80e172d41