### PR TITLE
Handle FormData parsing fallbacks in project upload API

### DIFF
--- a/server/api/projects/index.post.ts
+++ b/server/api/projects/index.post.ts
@@ -1,8 +1,93 @@
-import { readFormData } from "h3";
+import type { H3Event } from "h3";
+import * as h3 from "h3";
 import { createProject, saveVideoFile } from "~/server/db/projects";
 
+interface FormDataLike {
+  get(name: string): FormDataEntryValue | null;
+}
+
+interface MultipartFormData {
+  name: string;
+  data: Buffer;
+  filename?: string;
+  type?: string;
+}
+
+async function getFormData(event: H3Event): Promise<FormDataLike> {
+  if (typeof (h3 as any).readFormData === "function") {
+    return (h3 as any).readFormData(event);
+  }
+
+  if (typeof (h3 as any).readMultipartFormData === "function") {
+    const multipart = await (h3 as any).readMultipartFormData(event);
+    if (multipart) {
+      return createFormDataLikeFromMultipart(multipart as MultipartFormData[]);
+    }
+  }
+
+  const body = await (h3 as any).readBody?.(event);
+  if (body && typeof (body as FormDataLike).get === "function") {
+    return body as FormDataLike;
+  }
+
+  const entries = new Map<string, any>();
+  if (body && typeof body === "object") {
+    for (const [key, value] of Object.entries(body)) {
+      entries.set(key, value);
+    }
+  }
+
+  return {
+    get(name: string) {
+      return entries.has(name) ? entries.get(name) : null;
+    },
+  };
+}
+
+function createFormDataLikeFromMultipart(parts: MultipartFormData[]): FormDataLike {
+  const entries = new Map<string, FormDataEntryValue>();
+
+  for (const part of parts) {
+    if (!part.name) {
+      continue;
+    }
+
+    if (part.filename || part.type === "file") {
+      const file = createFileLike(part);
+      entries.set(part.name, file);
+    } else {
+      entries.set(part.name, part.data.toString("utf8"));
+    }
+  }
+
+  return {
+    get(name: string) {
+      return entries.has(name) ? entries.get(name) : null;
+    },
+  };
+}
+
+function createFileLike(part: MultipartFormData): File | Blob {
+  const blob = new Blob([part.data], {
+    type: part.type || "application/octet-stream",
+  });
+
+  if (typeof File === "function") {
+    return new File([part.data], part.filename || "file", {
+      type: part.type,
+    });
+  }
+
+  Object.defineProperty(blob, "name", {
+    value: part.filename || "file",
+    writable: false,
+  });
+
+  return blob;
+}
+
 export default defineEventHandler(async (event) => {
-  const formData = await readFormData(event);
+  const formData = await getFormData(event);
   const title = formData.get("title");
 
   if (typeof title !== "string" || !title.trim()) {

--- a/tests/server/api/projects/index.post.spec.ts
+++ b/tests/server/api/projects/index.post.spec.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 const readFormDataMock = vi.fn();
+const readMultipartFormDataMock = vi.fn();
+const readBodyMock = vi.fn();
 const createProjectMock = vi.fn();
 const saveVideoFileMock = vi.fn();
 let createErrorMock: ReturnType<typeof vi.fn>;
+
+let readFormDataImpl: ((...args: any[]) => any) | undefined;
+let readMultipartFormDataImpl: ((...args: any[]) => any) | undefined;
+let readBodyImpl: ((...args: any[]) => any) | undefined;
 
 declare global {
   // eslint-disable-next-line no-var
@@ -12,9 +18,35 @@ declare global {
   var createError: (input: any) => any;
 }
 
-vi.mock("h3", () => ({
-  readFormData: (...args: any[]) => readFormDataMock(...args),
-}));
+vi.mock("h3", () => {
+  const module: Record<string, any> = { __esModule: true };
+
+  Object.defineProperty(module, "readFormData", {
+    enumerable: true,
+    get: () => readFormDataImpl,
+    set: (value) => {
+      readFormDataImpl = value;
+    },
+  });
+
+  Object.defineProperty(module, "readMultipartFormData", {
+    enumerable: true,
+    get: () => readMultipartFormDataImpl,
+    set: (value) => {
+      readMultipartFormDataImpl = value;
+    },
+  });
+
+  Object.defineProperty(module, "readBody", {
+    enumerable: true,
+    get: () => readBodyImpl,
+    set: (value) => {
+      readBodyImpl = value;
+    },
+  });
+
+  return module;
+});
 
 vi.mock("~/server/db/projects", () => ({
   createProject: (...args: any[]) => createProjectMock(...args),
@@ -29,11 +61,17 @@ async function importHandler() {
 beforeEach(() => {
   vi.resetModules();
   readFormDataMock.mockReset();
+  readMultipartFormDataMock.mockReset();
+  readBodyMock.mockReset();
   createProjectMock.mockReset();
   saveVideoFileMock.mockReset();
   createErrorMock = vi.fn((input) => input);
   vi.stubGlobal("defineEventHandler", <T>(handler: T) => handler);
   vi.stubGlobal("createError", createErrorMock);
+
+  readFormDataImpl = (...args: any[]) => readFormDataMock(...args);
+  readMultipartFormDataImpl = (...args: any[]) => readMultipartFormDataMock(...args);
+  readBodyImpl = (...args: any[]) => readBodyMock(...args);
 });
 
 afterEach(() => {
@@ -82,5 +120,85 @@ describe("POST /api/projects", () => {
       videoPath: null,
     });
     expect(result).toEqual({ id: 123 });
+  });
+
+  it("saves the uploaded video when provided", async () => {
+    const file = {
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    };
+
+    readFormDataMock.mockResolvedValue({
+      get: (key: string) => {
+        if (key === "title") {
+          return "Project with video";
+        }
+        if (key === "file") {
+          return file;
+        }
+        return null;
+      },
+    });
+
+    createProjectMock.mockResolvedValue({ id: 456 });
+    saveVideoFileMock.mockResolvedValue("video-path.mp4");
+
+    const handler = await importHandler();
+    const result = await handler({} as any);
+
+    expect(saveVideoFileMock).toHaveBeenCalledWith(file, null);
+    expect(createProjectMock).toHaveBeenCalledWith({
+      title: "Project with video",
+      videoPath: "video-path.mp4",
+    });
+    expect(result).toEqual({ id: 456 });
+  });
+
+  it("falls back to multipart parsing when readFormData is unavailable", async () => {
+    readFormDataImpl = undefined;
+
+    readMultipartFormDataMock.mockResolvedValue([
+      { name: "title", data: Buffer.from("Multipart Title") },
+      {
+        name: "file",
+        data: Buffer.from("content"),
+        filename: "video.mp4",
+        type: "video/mp4",
+      },
+    ]);
+
+    createProjectMock.mockResolvedValue({ id: 789 });
+    saveVideoFileMock.mockResolvedValue("stored.mp4");
+
+    const handler = await importHandler();
+    const result = await handler({} as any);
+
+    expect(readMultipartFormDataMock).toHaveBeenCalled();
+    const [fileArg, nameArg] = saveVideoFileMock.mock.calls[0];
+    expect(typeof (fileArg as Blob).arrayBuffer).toBe("function");
+    expect(nameArg).toBe("video.mp4");
+    expect(createProjectMock).toHaveBeenCalledWith({
+      title: "Multipart Title",
+      videoPath: "stored.mp4",
+    });
+    expect(result).toEqual({ id: 789 });
+  });
+
+  it("falls back to parsing the request body when multipart data is unavailable", async () => {
+    readFormDataImpl = undefined;
+    readMultipartFormDataMock.mockResolvedValue(null);
+    readBodyMock.mockResolvedValue({ title: "Body Title" });
+
+    createProjectMock.mockResolvedValue({ id: 321 });
+
+    const handler = await importHandler();
+    const result = await handler({} as any);
+
+    expect(readBodyMock).toHaveBeenCalled();
+    expect(saveVideoFileMock).not.toHaveBeenCalled();
+    expect(createProjectMock).toHaveBeenCalledWith({
+      title: "Body Title",
+      videoPath: null,
+    });
+    expect(result).toEqual({ id: 321 });
   });
 });


### PR DESCRIPTION
## Summary
- add compatibility fallbacks for reading FormData in the project creation API when `readFormData` is unavailable
- convert multipart payloads into File or Blob objects and reuse existing save logic
- expand the POST /api/projects test suite to cover multipart, body fallback, and file upload scenarios

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68de543105c4832a81d2fef816cb3ca7